### PR TITLE
Enable `shell-escape` to let latexmk execute external commands properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export TEXINPUTS = .::$TEXMF/tex::../pl-syntax
 all: $(TEX_FILES:.tex=.pdf)
 
 %.pdf: %.tex $(STYLES)
-	latexmk -pdf -synctex=1 -pdflatex=lualatex $<
+	latexmk -pdf -shell-escape -synctex=1 -pdflatex=lualatex $<
 
 %.tex: %.lagda.tex
 	agda --latex --latex-dir=. $<

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The notes are written in a combination of (lua)latex and literate agda. Both a m
 
 The easiest way of building the notes is by running `make`. This will build all of the notes into pdf files.
 
-Alternatively, `.tex` files can be built using `latexmk` as follows: `latexmk --pdf --synctex=1 --pdflatex=lualatex $FILE` (replacing `$FILE` with the name of the file you want to build).
+Alternatively, `.tex` files can be built using `latexmk` as follows: `latexmk --pdf -shell-escape --synctex=1 --pdflatex=lualatex $FILE` (replacing `$FILE` with the name of the file you want to build).
 In order to build a `.tex` file from a `.lagda.tex` file, you must use `agda` as follows: `agda --latex --latex-dir=. $FILE`.
 
 ## Contributing


### PR DESCRIPTION
The original Makefile will prompt the following error at compile time:

```
runsystem(mkdir -p _minted-lec01)...(Command execution disabled via shell_escape ='p').


! Package minted Error: You must invoke LaTeX with the -shell-escape flag.

See the minted package documentation for explanation.
Type  H <return>  for immediate help.
...  
```
